### PR TITLE
Add global 'block_caret' to improve the nord experience in Vintage mode

### DIFF
--- a/Nord.sublime-color-scheme
+++ b/Nord.sublime-color-scheme
@@ -59,6 +59,7 @@
     "brackets_foreground": "var(nord8)",
     "brackets_options": "underline",
     "caret": "var(nord_text)",
+    "block_caret": "color(var(nord_text) alpha(0.5))",
     "find_highlight_foreground": "var(nord0)",
     "find_highlight": "var(nord8)",
     "foreground": "var(nord_text)",


### PR DESCRIPTION
Sublime's block cursor is barely visible with the current `develop` version of Nord. The block cursor is present when sublime is in command mode, e.g. by using the Vintage package (Vim-style keybindings).

I'm not sure about the exact color value to use and I'm happy to adjust. Here's a comparison between `develop` and this PR.

BEFORE
![nord_block_caret_BEFORE](https://user-images.githubusercontent.com/5539930/62761205-4f47cb80-ba86-11e9-96b2-cb39d8fa3a23.png)

AFTER
![nord_block_caret_AFTER](https://user-images.githubusercontent.com/5539930/62761206-5078f880-ba86-11e9-9aef-431e952299d0.png)
